### PR TITLE
Fix: no solutuion error if initial solution

### DIFF
--- a/tsp_simple.cc
+++ b/tsp_simple.cc
@@ -1244,7 +1244,7 @@ int TSPTWSolver(const TSPTWDataDT& data, std::string filename) {
     routing.AddSearchMonitor(limit);
   }
 
-  if (((data.Routes().size() > 0 && build_route) || data.OrderCounter() == 1) &&
+  if (data.Routes().size() > 0 && build_route &&
       routing.solver()->CheckAssignment(assignment)) {
     std::cout << "Using initial solution provided." << std::endl;
     solution = routing.SolveFromAssignmentWithParameters(assignment, parameters);

--- a/tsp_simple.cc
+++ b/tsp_simple.cc
@@ -1222,6 +1222,11 @@ int TSPTWSolver(const TSPTWDataDT& data, std::string filename) {
         LocalSearchMetaheuristic::GUIDED_LOCAL_SEARCH);
   }
 
+  if (data.Routes().size() > 0){
+    CHECK_OK(util_time::EncodeGoogleApiProto(absl::Milliseconds(1000), // 1.0s
+                                             parameters.mutable_lns_time_limit()));
+  }
+
   routing.CloseModelWithParameters(parameters);
 
   bool build_route = RouteBuilder(data, routing, manager, assignment);

--- a/tsptw_data_dt.h
+++ b/tsptw_data_dt.h
@@ -152,8 +152,6 @@ public:
 
   int64 TwiceTWsCounter() const { return multiple_tws_counter_; }
 
-  int64 OrderCounter() const { return order_counter_; }
-
   int64 DeliveriesCounter() const { return deliveries_counter_; }
 
   int64 IdIndex(std::string id) const {
@@ -674,7 +672,6 @@ private:
   int64 max_service_;
   int64 max_rest_;
   int64 tws_counter_;
-  int64 order_counter_;
   int64 deliveries_counter_;
   int64 multiple_tws_counter_;
   std::map<std::string, int64> ids_map_;
@@ -699,7 +696,6 @@ void TSPTWDataDT::LoadInstance(const std::string& filename) {
   multiple_tws_counter_ = 0;
   deliveries_counter_   = 0;
   int32 matrix_index    = 0;
-  order_counter_        = 0;
   size_problem_         = 0;
   std::vector<int64> matrix_indices;
   for (const ortools_vrp::Service& service : problem.services()) {
@@ -1002,7 +998,6 @@ void TSPTWDataDT::LoadInstance(const std::string& filename) {
       relType = Sequence;
     else if (relation.type() == "order") {
       relType = Order;
-      ++order_counter_;
     } else if (relation.type() == "same_route")
       relType = SameRoute;
     else if (relation.type() == "minimum_day_lapse")


### PR DESCRIPTION
When initial solution is provided; if the cpu is occupied, local search (or-tools) 
marks valid branches as `failure` (because it cannot succeed to make a 
successful iteration within ls_time_limit) which leads to `No solution found`

To prevent this case, we increase the `ls_time_limit` preemptively

- [ ] @braktar will test this for general case and if the impact is positive it will 
be activated in general.