### PR TITLE
Move to passenger-ruby25 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG REGISTRY=${REGISTRY:-registry.mapotempo.com/}
 
 # Final image
 # Build wrapper
-FROM debian:latest
+FROM phusion/passenger-ruby25
 ARG ORTOOLS_URL
 
 WORKDIR /srv/


### PR DESCRIPTION
Base build on phusion/passenger-ruby25 to avoid errors in optimizer-api due to Debian and Ubuntu lib differences.