### PR TITLE
[optim-api-related] Fixes for maj

### DIFF
--- a/limits.h
+++ b/limits.h
@@ -586,7 +586,7 @@ public:
 
       if (intermediate_ == false)
         std::cout << " \tInternal cost : " /* The `c` of cost needs to stay lowercase */
-                  << cleaned_cost_ / CUSTOM_BIGNUM;
+                  << cleaned_cost_;
 
       std::cout << " \tTime : " << 1e-9 * (absl::GetCurrentTimeNanos() - start_time_)
                 << std::endl;

--- a/limits.h
+++ b/limits.h
@@ -272,7 +272,7 @@ public:
                 ->Max()) *
            routing_->GetMutableDimension(dimension_name)
                ->GetSpanCostCoefficientForVehicle(vehicle) /
-           CUSTOM_BIGNUM;
+           CUSTOM_BIGNUM_COST;
   }
 
   inline double GetUpperBoundCostForDimension(const int index,
@@ -287,7 +287,7 @@ public:
     return (double)excess *
            routing_->GetMutableDimension(dimension_name)
                ->GetCumulVarSoftUpperBoundCoefficient(index) /
-           CUSTOM_BIGNUM;
+           CUSTOM_BIGNUM_COST;
   }
 
   virtual bool AtSolution() {
@@ -423,7 +423,7 @@ public:
 
           if (vehicle_used) {
             const double fixed_cost =
-                routing_->GetFixedCostOfVehicle(route_nbr) / CUSTOM_BIGNUM;
+                routing_->GetFixedCostOfVehicle(route_nbr) / CUSTOM_BIGNUM_COST;
             route_costs->set_fixed(fixed_cost);
             total_vehicle_fixed_cost += fixed_cost;
             ++nbr_routes;
@@ -495,7 +495,7 @@ public:
           }
         }
 
-        cleaned_cost_ = best_result_ / CUSTOM_BIGNUM -
+        cleaned_cost_ = best_result_ / CUSTOM_BIGNUM_COST -
                         (total_time_order_cost + total_distance_order_cost +
                          total_rest_position_cost);
         result_->set_cost(cleaned_cost_);
@@ -548,7 +548,7 @@ public:
           total_rest_position_cost +=
               GetSpanCostForVehicleForDimension(route_nbr, kRestPosition);
         }
-        cleaned_cost_ = best_result_ / CUSTOM_BIGNUM -
+        cleaned_cost_ = best_result_ / CUSTOM_BIGNUM_COST -
                         (total_time_order_cost + total_distance_order_cost +
                          total_rest_position_cost);
       }
@@ -625,15 +625,15 @@ public:
   }
 
   std::vector<double> GetFinalScore() {
-    return {(cleaned_cost_ / CUSTOM_BIGNUM),
+    return {(cleaned_cost_ / CUSTOM_BIGNUM_COST),
             1e-9 * (absl::GetCurrentTimeNanos() - start_time_),
             (double)iteration_counter_};
   }
 
   // void GetFinalLog() {
   //   std::cout << "Final Iteration : " << iteration_counter_ << " Cost : " <<
-  //   best_result_ / CUSTOM_BIGNUM << " Time : " << 1e-9 * (base::GetCurrentTimeNanos() -
-  //   start_time_) << std::endl;
+  //   best_result_ / CUSTOM_BIGNUM_COST << " Time : " << 1e-9 *
+  //   (base::GetCurrentTimeNanos() - start_time_) << std::endl;
   // }
 
 private:

--- a/limits.h
+++ b/limits.h
@@ -374,7 +374,7 @@ public:
                   routing_->GetMutableDimension("quantity" + std::to_string(q))
                       ->CumulVar(routing_->NextVar(index)->Value())
                       ->Min();
-              activity->add_quantities(exchange);
+              activity->add_quantities(exchange / CUSTOM_BIGNUM_QUANTITY);
               overload_cost += GetUpperBoundCostForDimension(
                   routing_->NextVar(index)->Value(), "quantity" + std::to_string(q));
             }

--- a/ortools_vrp.proto
+++ b/ortools_vrp.proto
@@ -16,7 +16,7 @@ message TimeWindow {
 
 message Service {
   repeated TimeWindow time_windows = 1;
-  repeated int64 quantities        = 2;
+  repeated float quantities        = 2;
   uint32 duration                  = 3;
   uint32 priority                  = 4;
   repeated int32 vehicle_indices   = 5;
@@ -24,7 +24,7 @@ message Service {
   uint32 setup_duration            = 7;
   string id                        = 9;
   float late_multiplier            = 10;
-  repeated int32 setup_quantities  = 11;
+  repeated float setup_quantities  = 11;
   uint32 additional_value          = 12;
   int64 exclusion_cost             = 13;
   repeated bool refill_quantities  = 14;
@@ -40,7 +40,7 @@ message Rest {
 }
 
 message Capacity {
-  int64 limit               = 1;
+  float limit               = 1;
   float overload_multiplier = 2;
   bool counting             = 3;
 }

--- a/tsp_simple.cc
+++ b/tsp_simple.cc
@@ -65,7 +65,7 @@ double GetSpanCostForVehicleForDimension(const RoutingModel& routing,
                             ->CumulVar(routing.Start(vehicle)))) *
          routing.GetMutableDimension(dimension_name)
              ->GetSpanCostCoefficientForVehicle(vehicle) /
-         CUSTOM_BIGNUM;
+         CUSTOM_BIGNUM_COST;
 }
 
 double GetUpperBoundCostForDimension(const RoutingModel& routing,
@@ -81,7 +81,7 @@ double GetUpperBoundCostForDimension(const RoutingModel& routing,
   return excess *
          routing.GetMutableDimension(dimension_name)
              ->GetCumulVarSoftUpperBoundCoefficient(index) /
-         CUSTOM_BIGNUM;
+         CUSTOM_BIGNUM_COST;
 }
 
 void MissionsBuilder(const TSPTWDataDT& data, RoutingModel& routing,
@@ -257,7 +257,8 @@ RestBuilder(const TSPTWDataDT& data, RoutingModel& routing, const int64 horizon)
     RoutingDimension* rest_dimension = routing.GetMutableDimension(kRestPosition);
     // Add a small cost so that pause will be pushed towards the end of the route if it
     // doesn't increase other costs. Note: the cost coefficient is actually very small
-    // (1 / CUSTOM_BIGNUM) since every other cost is multipled with CUSTOM_BIGNUM
+    // (1 / CUSTOM_BIGNUM_COST) since every other cost is multipled with
+    // CUSTOM_BIGNUM_COST
     rest_dimension->SetSpanCostCoefficientForVehicle(1, vehicle_index);
     rest_dimension->CumulVar(routing.Start(vehicle_index))->SetMax(0);
 
@@ -890,7 +891,7 @@ void AddTimeDimensions(const TSPTWDataDT& data, RoutingModel& routing,
     if (vehicle.shift_preference == ForceStart &&
         vehicle.cost_waiting_time_multiplier >= vehicle.cost_time_multiplier) {
       if (vehicle.cost_time_multiplier == 0 && vehicle.cost_distance_multiplier == 0) {
-        // TODO: verify but it shouldn't be necessary to multiply with CUSTOM_BIGNUM
+        // TODO: verify but it shouldn't be necessary to multiply with CUSTOM_BIGNUM_COST
         // since we just want to create a small incentive
         const_cast<TSPTWDataDT::Vehicle&>(vehicle).cost_time_multiplier = 1;
       }
@@ -1259,7 +1260,8 @@ void ParseSolutionIntoResult(const Assignment* const solution,
     auto route_costs = route->mutable_cost_details();
 
     if (vehicle_used) {
-      const double fixed_cost = routing.GetFixedCostOfVehicle(route_nbr) / CUSTOM_BIGNUM;
+      const double fixed_cost =
+          routing.GetFixedCostOfVehicle(route_nbr) / CUSTOM_BIGNUM_COST;
       route_costs->set_fixed(fixed_cost);
       DLOG(INFO) << "RouteEndValues:" << route_nbr << "\t start_time: " << start_time
                  << std::endl;
@@ -1324,7 +1326,7 @@ void ParseSolutionIntoResult(const Assignment* const solution,
 
   std::vector<double> scores = logger->GetFinalScore();
   result->set_cost(
-      solution->ObjectiveValue() / CUSTOM_BIGNUM -
+      solution->ObjectiveValue() / CUSTOM_BIGNUM_COST -
       (total_time_order_cost + total_distance_order_cost + total_rest_position_cost));
   result->set_duration(scores[1]);
   result->set_iterations(scores[2]);

--- a/tsp_simple.cc
+++ b/tsp_simple.cc
@@ -1212,7 +1212,7 @@ void ParseSolutionIntoResult(const Assignment* const solution,
         const double exchange =
             solution->Min(routing.GetMutableDimension("quantity" + std::to_string(q))
                               ->CumulVar(solution->Value(routing.NextVar(index))));
-        activity->add_quantities(exchange);
+        activity->add_quantities(exchange / CUSTOM_BIGNUM_QUANTITY);
         overload_cost += GetUpperBoundCostForDimension(
             routing, solution, solution->Value(routing.NextVar(index)),
             "quantity" + std::to_string(q));

--- a/tsptw_data_dt.h
+++ b/tsptw_data_dt.h
@@ -17,7 +17,7 @@
 
 #define CUSTOM_MAX_INT (int64) std::pow(2, 30)
 
-#define CUSTOM_BIGNUM 1e6
+#define CUSTOM_BIGNUM_COST 1e6
 
 enum RelationType {
   MinimumDurationLapse = 15,
@@ -770,10 +770,12 @@ void TSPTWDataDT::LoadInstance(const std::string& filename) {
             alternative_size_map_[service.problem_index()], start, end,
             service.duration(), service.additional_value(), service.setup_duration(),
             service.priority(),
-            timewindows.size() > 0 ? (int64)(service.late_multiplier() * CUSTOM_BIGNUM)
-                                   : 0,
+            timewindows.size() > 0
+                ? (int64)(service.late_multiplier() * CUSTOM_BIGNUM_COST)
+                : 0,
             v_i, q, s_q,
-            service.exclusion_cost() > 0 ? service.exclusion_cost() * CUSTOM_BIGNUM : -1,
+            service.exclusion_cost() > 0 ? service.exclusion_cost() * CUSTOM_BIGNUM_COST
+                                         : -1,
             r_q));
 
         service_times_.push_back(service.duration());
@@ -790,9 +792,11 @@ void TSPTWDataDT::LoadInstance(const std::string& filename) {
           alternative_size_map_[service.problem_index()], ready_time, due_time,
           service.duration(), service.additional_value(), service.setup_duration(),
           service.priority(),
-          timewindows.size() > 0 ? (int64)(service.late_multiplier() * CUSTOM_BIGNUM) : 0,
+          timewindows.size() > 0 ? (int64)(service.late_multiplier() * CUSTOM_BIGNUM_COST)
+                                 : 0,
           v_i, q, s_q,
-          service.exclusion_cost() > 0 ? service.exclusion_cost() * CUSTOM_BIGNUM : -1,
+          service.exclusion_cost() > 0 ? service.exclusion_cost() * CUSTOM_BIGNUM_COST
+                                       : -1,
           r_q));
       service_times_.push_back(service.duration());
       alternative_size_map_[service.problem_index()] += 1;
@@ -867,7 +871,8 @@ void TSPTWDataDT::LoadInstance(const std::string& filename) {
 
     for (const ortools_vrp::Capacity& capacity : vehicle.capacities()) {
       v->capacity.push_back(capacity.limit());
-      v->overload_multiplier.push_back(capacity.overload_multiplier() * CUSTOM_BIGNUM);
+      v->overload_multiplier.push_back(capacity.overload_multiplier() *
+                                       CUSTOM_BIGNUM_COST);
       v->counting.push_back(capacity.counting());
     }
 
@@ -883,22 +888,24 @@ void TSPTWDataDT::LoadInstance(const std::string& filename) {
     v->time_end = vehicle.time_window().end() < CUSTOM_MAX_INT
                       ? vehicle.time_window().end()
                       : CUSTOM_MAX_INT;
-    v->late_multiplier = (int64)(vehicle.cost_late_multiplier() * CUSTOM_BIGNUM);
-    v->cost_fixed      = (int64)(vehicle.cost_fixed() * CUSTOM_BIGNUM);
+    v->late_multiplier = (int64)(vehicle.cost_late_multiplier() * CUSTOM_BIGNUM_COST);
+    v->cost_fixed      = (int64)(vehicle.cost_fixed() * CUSTOM_BIGNUM_COST);
     v->cost_distance_multiplier =
-        (int64)(vehicle.cost_distance_multiplier() * CUSTOM_BIGNUM);
-    v->cost_time_multiplier = (int64)(vehicle.cost_time_multiplier() * CUSTOM_BIGNUM);
+        (int64)(vehicle.cost_distance_multiplier() * CUSTOM_BIGNUM_COST);
+    v->cost_time_multiplier =
+        (int64)(vehicle.cost_time_multiplier() * CUSTOM_BIGNUM_COST);
     v->cost_waiting_time_multiplier =
-        (int64)(vehicle.cost_waiting_time_multiplier() * CUSTOM_BIGNUM);
-    v->cost_value_multiplier = (int64)(vehicle.cost_value_multiplier() * CUSTOM_BIGNUM);
-    v->coef_service          = vehicle.coef_service();
-    v->additional_service    = vehicle.additional_service();
-    v->coef_setup            = vehicle.coef_setup();
-    v->additional_setup      = vehicle.additional_setup();
-    v->duration              = (int64)(vehicle.duration());
-    v->distance              = vehicle.distance();
-    v->free_approach         = vehicle.free_approach();
-    v->free_return           = vehicle.free_return();
+        (int64)(vehicle.cost_waiting_time_multiplier() * CUSTOM_BIGNUM_COST);
+    v->cost_value_multiplier =
+        (int64)(vehicle.cost_value_multiplier() * CUSTOM_BIGNUM_COST);
+    v->coef_service       = vehicle.coef_service();
+    v->additional_service = vehicle.additional_service();
+    v->coef_setup         = vehicle.coef_setup();
+    v->additional_setup   = vehicle.additional_setup();
+    v->duration           = (int64)(vehicle.duration());
+    v->distance           = vehicle.distance();
+    v->free_approach      = vehicle.free_approach();
+    v->free_return        = vehicle.free_return();
     if (vehicle.shift_preference().compare("force_start") == 0)
       v->shift_preference = ForceStart;
     else if (vehicle.shift_preference().compare("force_end") == 0)


### PR DESCRIPTION
Move quantity and capacity multiplication to optim-ortools side so that the costs will be correct inside or-tools and after optimization on the optim-api side.

- Fixes a double division bug of internal cost
- Renames CUSTOM_BIGNUM into CUSTOM_BIGNUM_COST
- Introduces CUSTOM_BIGNUM_QUANTITY for quantity multiplication