### PR TITLE
Set PR works by removing call to secrets

### DIFF
--- a/.github/actions/build.sh
+++ b/.github/actions/build.sh
@@ -8,6 +8,7 @@ if [[ $GITHUB_REF == *tags* ]]; then
 else
   echo "> Building image for dev purpose (${REPOSITORY}) with or-tools ${ORTOOLS_VERSION}"
   TAG=$(echo "${REPOSITORY}" | sed "s/\/.*//")
+  REGISTRY=${REGISTRY:-registry.test.com}
 fi
 
 IMAGE_NAME=${REGISTRY}/mapotempo-ce/optimizer-ortools:${TAG}


### PR DESCRIPTION
As mentioned in this [article](https://stackoverflow.com/questions/58737785/github-actions-empty-env-secrets) PR cannot use the repository secrets for security purpose. I could use the [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event but I do not fill it safe enough. Only people with granted access to push to Mapotempo should use those secrets.

cc https://github.com/Mapotempo/optimizer-ortools/pull/25